### PR TITLE
Hide drawer menu labels depends on user role

### DIFF
--- a/apps/frontend/go4success/app/(app)/_layout.tsx
+++ b/apps/frontend/go4success/app/(app)/_layout.tsx
@@ -9,10 +9,10 @@ import { Image, Platform, TouchableOpacity, View } from "react-native";
 import { useRouter } from "expo-router";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import { useTranslation } from "react-i18next";
-
 import profilePicture from "@/assets/images/profile-picture.jpg";
+import useUser from "@/hooks/useUser";
 
-function customDrawerContent(props: any) {
+function CustomDrawerContent(props: any) {
     const router = useRouter();
     const { t } = useTranslation();
     const { signOut } = useAuth();
@@ -46,12 +46,15 @@ function customDrawerContent(props: any) {
 
 export default function Layout() {
     const router = useRouter();
+
+    const { user } = useUser();
+
     const { t } = useTranslation();
     return (
         <GestureHandlerRootView style={{ flex: 1 }}>
             <AuthProvider>
                 <Drawer
-                    drawerContent={customDrawerContent}
+                    drawerContent={CustomDrawerContent}
                     screenOptions={{
                         drawerHideStatusBarOnOpen: true,
                         drawerActiveBackgroundColor: Colors.primaryColor,
@@ -172,8 +175,9 @@ export default function Layout() {
                     <Drawer.Screen
                         name="rolemanagement"
                         options={{
-                            drawerLabel: "Gestion des rôles",
-                            headerTitle: "Gestion des rôles",
+                            drawerItemStyle: { display: user?.is_superuser ? "flex" : "none" },
+                            drawerLabel: t("translationMenu.rolemanagement"),
+                            headerTitle: t("translationMenu.rolemanagement"),
                             drawerIcon: ({ size, color }) => (
                                 <Ionicons name="people" size={size} color={color} />
                             ),

--- a/apps/frontend/go4success/context/Auth.tsx
+++ b/apps/frontend/go4success/context/Auth.tsx
@@ -13,6 +13,12 @@ import { fetchBackend } from "@/utils/fetchBackend";
 import { fetchError } from "@/utils/fetchError";
 import useUser from "@/hooks/useUser";
 
+function isListIncluded(mainList: any[][], searchList: any[]): boolean {
+    return mainList.some(subList =>
+        subList.length === searchList.length && subList.every((value, index) => value === searchList[index]),
+    );
+}
+
 const AuthContext = React.createContext<any>(null);
 
 export function useAuth() {
@@ -21,7 +27,7 @@ export function useAuth() {
 
 export function AuthProvider({ children }: React.PropsWithChildren) {
     const { t } = useTranslation();
-    const rootSegment = useSegments()[0];
+    const rootSegment = useSegments();
 
     const { isPending, user } = useUser();
 
@@ -35,9 +41,19 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
         );
     }
 
-    if (!user && rootSegment !== "(auth)") {
+    if (!user && rootSegment[0] !== "(auth)") {
         return <Redirect href={"/(auth)/login"} />;
-    } else if (user && rootSegment === "(auth)") {
+    } else if (user && rootSegment[0] === "(auth)") {
+        return <Redirect href={"/"} />;
+    }
+
+    const deniedRoutesForNonSuperUser = [
+        ["(app)", "rolemanagement"],
+    ];
+
+    const isNotSuperUser = !user?.is_superuser && user;
+
+    if (isNotSuperUser && isListIncluded(deniedRoutesForNonSuperUser, rootSegment)) {
         return <Redirect href={"/"} />;
     }
 
@@ -152,10 +168,10 @@ export function AuthProvider({ children }: React.PropsWithChildren) {
 
                 signOut: async () => {
                     try {
-                        AsyncStorage.removeItem("accessToken");
-                        AsyncStorage.removeItem("refreshToken");
+                        await AsyncStorage.removeItem("accessToken");
+                        await AsyncStorage.removeItem("refreshToken");
 
-                        void queryClient.invalidateQueries({
+                        await queryClient.invalidateQueries({
                             queryKey: ["current_user"],
                         });
                         Toast.show({


### PR DESCRIPTION
J'ai réussi à trouver un moyen de cacher et restreindre l'accès à certaines pages du menu ou pas, selon le role de l'utilisateurs. 

Donc voici ce qui faut faire : 

1. Si vous voulez cacher dans le menu, il faut aller dans le ```(app)/_layout.tsx``` et mettre dans les options du drawer.Screen qu'on souhaite cacher, ceci : ```drawerItemStyle: { display: condition ? "flex" : "none" } ```
2. Pour restreindre l'accès à la page s'il n'est pas superuser par exemple, il faut ajouter dans ```Auth.tsx```, dans la variable ```deniedRoutesForNonSuperUser```, une liste représentant la rootSegment de la page, selon la structure des fichiers comme ceci, pour la page des gestion des roles par exemple : 
```tsx
const deniedRoutesForNonSuperUser = [
   ["(app)", "rolemanagement"],
   // ajouter des routes si besoin
];

 ```
Ceci est ajouté pour faire la redirection si jamais il n'est pas superUser et donc qu'il n'a pas accès à ces pages :
```tsx
    const isNotSuperUser = !user?.is_superuser && user;

    if (isNotSuperUser && isListIncluded(deniedRoutesForNonSuperUser, rootSegment)) {
        return <Redirect href={"/"} />;
    }
```

et donc vous l'avez compris, si vous avez besoin de restreindre des accès pour les user qui sont pas prof, il faudra créer une variable ```deniedRoutesForNonProfessor```,  créer un ```if``` et redirect.